### PR TITLE
PLAT-39440 emodule artifacts are broken for 5.2

### DIFF
--- a/attivio-archetype-client/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/attivio-archetype-client/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -1,15 +1,18 @@
 def moduleDir = new File(request.getOutputDirectory()+"/"+request.getArtifactId())
 
 // Find Attivio installation
-def env = System.getenv()
-def attivioHome = env['ATTIVIO_HOME']
+def attivioHome = System.getenv('ATTIVIO_HOME')
 if (attivioHome == null) {
-    env['PATH'].split(System.getProperty("path.separator")).each { p ->
-	if (new File(p+"/../conf/attivio.license").exists()) {
-	    attivioHome = new File(p).getParent();
-	}
+  systemPath = System.getenv('PATH')
+  if (systemPath != null) {
+    systemPath.split(System.getProperty("path.separator")).each { p ->
+      if (new File(p+"/../conf/attivio.license").exists()) {
+        attivioHome = new File(p).getParent();
+      }
+        }
     }
 }
+
 if (attivioHome == null) {
     println "Client requires Attivio installation and Attivio was not found on path"
     attivioHome = System.console().readLine 'Attivio Installation Directory?: '

--- a/attivio-archetype-module/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/attivio-archetype-module/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -7,10 +7,10 @@ def webappsDir = new File(moduleDir, "src/main/resources/webapps/${artifactId}")
 // replace com.sample with the group and artifact ids
 moduleDir.eachDirRecurse() { dir ->
     dir.eachFileMatch(~/.*.java/) { file ->
-	String code = file.getText('UTF-8').replaceAll('com.sample.module', request.getGroupId()+'.'+request.getArtifactId())
-	file.newWriter().withWriter { w ->
-	    w << code
-	}
+        String code = file.getText('UTF-8').replaceAll('com.sample', request.getGroupId()+'.'+request.getArtifactId())
+        file.newWriter().withWriter { w ->
+            w << code
+        }
     }
 }
 
@@ -18,21 +18,16 @@ moduleDir.eachDirRecurse() { dir ->
 def includeWeb = request.getProperties().getProperty('includeWeb')
 
 // Find Attivio installation
-def env = System.getenv()
-def attivioHome = env['ATTIVIO_HOME']
+def attivioHome = System.getenv('ATTIVIO_HOME')
 if (attivioHome == null) {
-    env['PATH'].split(System.getProperty("path.separator")).each { p ->
-	if (new File(p+"/../conf/attivio.license").exists()) {
-	    attivioHome = new File(p).getParent();
-	}
+    systemPath = System.getenv('PATH')
+    if (systemPath != null) {
+        systemPath.split(System.getProperty("path.separator")).each { p ->
+            if (new File(p+"/../conf/attivio.license").exists()) {
+                attivioHome = new File(p).getParent();
+            }
+        }
     }
-}
-if (includeWeb && attivioHome == null) {
-    println "Web inclusion requires Attivio installation and Attivio was not found on path"
-    attivioHome = System.console().readLine 'Attivio Installation Directory?: '
-}
-if (attivioHome != null) {
-    println "Attivio installed at: ${attivioHome}"
 }
 
 // handle inclusion of web servlet
@@ -49,7 +44,7 @@ def webDependencies = """
       <version>\044{attivio.version}</version>
       <scope>system</scope>
       <systemPath>${attivioHome}/lib/aie-core-app.jar</systemPath>
-    </dependency>  
+    </dependency>
     <dependency>
         <groupId>javax.servlet</groupId>
         <artifactId>javax.servlet-api</artifactId>

--- a/attivio-archetype-module/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/attivio-archetype-module/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -7,7 +7,7 @@ def webappsDir = new File(moduleDir, "src/main/resources/webapps/${artifactId}")
 // replace com.sample with the group and artifact ids
 moduleDir.eachDirRecurse() { dir ->
     dir.eachFileMatch(~/.*.java/) { file ->
-        String code = file.getText('UTF-8').replaceAll('com.sample', request.getGroupId()+'.'+request.getArtifactId())
+        String code = file.getText('UTF-8').replaceAll('com.sample.module', request.getGroupId()+'.'+request.getArtifactId())
         file.newWriter().withWriter { w ->
             w << code
         }
@@ -28,6 +28,13 @@ if (attivioHome == null) {
             }
         }
     }
+}
+if (includeWeb && attivioHome == null) {
+    println "Web inclusion requires Attivio installation and Attivio was not found on path"
+    attivioHome = System.console().readLine 'Attivio Installation Directory?: '
+}
+if (attivioHome != null) {
+    println "Attivio installed at: ${attivioHome}"
 }
 
 // handle inclusion of web servlet


### PR DESCRIPTION
On Windows, `env['PATH']` returns null because it's apparently doing case-sensitive comparison (variable name is `Path`). 

However, using `System.getenv('PATH')` _will_ ignore case and return the path properly. This means no changes need to be made on the Linux side.

### Test procedure
Perform on both Windows and Linux systems:
1. `mvn clean install`
1. `mvn archetype:generate -DarchetypeGroupId=com.attivio.platform.archetypes -DarchetypeArtifactId=attivio-archetype-module -DarchetypeVersion=5.2.6.1-SNAPSHOT`
     * Ensure archetype is generated successfully
1. `mvn archetype:generate -DarchetypeGroupId=com.attivio.platform.archetypes -DarchetypeArtifactId=attivio-archetype-client -DarchetypeVersion=5.2.6.1-SNAPSHOT`
     * Ensure archetype is generated successfully

Tested on both Windows and Linux with no issues.

Once approved this change will need to be merged into `develop` and `4.4`.